### PR TITLE
Wrap a Linux-specific test in a TODO block

### DIFF
--- a/t/65-seg_size.t
+++ b/t/65-seg_size.t
@@ -26,7 +26,11 @@ if ($record =~ /bytes=(\d+)/s) {
 }
 
 is BYTES, $size, "size param is the same as the segment size";
-is $size, $actual_size, "actual size in bytes ok if sending in custom size";
+
+TODO: {
+    local $TODO = 'Not yet working on FreeBSD or macOS';
+    is $size, $actual_size, "actual size in bytes ok if sending in custom size";
+};
 
 $k->clean_up_all;
 


### PR DESCRIPTION
The `-i` option to `ipcs` looks like a Linuxism.

This PR allows the test suite to pass on other platforms by wrapping the related test in a `TODO:` block.

Fixes #8.
